### PR TITLE
Add TypeScript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "target": "es6",
+    "module": "commonjs",
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
Fixes #26.

I based this mostly off the configs from OpenZeppelin SDK and solidity-docgen. There are some differences that I felt were specific to each project setup, like `allowJs`.